### PR TITLE
tldr: Use `main` branch instead of `master`

### DIFF
--- a/bin/tldrb
+++ b/bin/tldrb
@@ -20,7 +20,7 @@ module Tldrb::Functions
   end
 
   def download_page(query, platform)
-    url = "https://raw.github.com/tldr-pages/tldr/master/pages/" \
+    url = "https://raw.github.com/tldr-pages/tldr/main/pages/" \
       "#{platform}/#{query}.md"
     open(url).read
   end


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the master branch in favour of the main branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).